### PR TITLE
Lowered the target framework to Android Marshmallow (6.0)

### DIFF
--- a/SamsungAccessorySDK.nuspec
+++ b/SamsungAccessorySDK.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>SamsungAccessorySDK.Net</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <title>SamsungAccessorySDK.Net</title>
     <authors>Emil Alipiev</authors>
     <owners>EmilAlipiev</owners>
@@ -10,13 +10,13 @@
     <projectUrl>https://github.com/EmilAlipiev/SamsungAccessorySDK.Net</projectUrl>
 	<repository type="git" url="https://github.com/EmilAlipiev/SamsungAccessorySDK.Net" />
     <description>SamsungAccessorySDK.net is .net implementation for Xamarin.Android projects</description>
-    <releaseNotes></releaseNotes>
+    <releaseNotes>Lowered the target framework to Android Marshmallow (6.0)</releaseNotes>
     <tags>Samsung Accessory SDK, Samsung, SaAgent, SaAgentV2, Tizen, Watch, wearable</tags>    
 	<license type="expression">MIT</license>
   </metadata>
    <files>      
       <!--Android-->
-      <file src="SamsungAccessorySDK\bin\Release\SamsungAccessorySDKNet.dll" target="lib\MonoAndroid10" />  
-	  <file src="SamsungAccessorySDK\bin\Release\SamsungAccessorySDKNet.pdb" target="lib\MonoAndroid10" />  
+      <file src="SamsungAccessorySDK\bin\Release\SamsungAccessorySDKNet.dll" target="lib\MonoAndroid60" />  
+	  <file src="SamsungAccessorySDK\bin\Release\SamsungAccessorySDKNet.pdb" target="lib\MonoAndroid60" />  
     </files>
 </package>

--- a/SamsungAccessorySDK/SamsungAccessorySDK.csproj
+++ b/SamsungAccessorySDK/SamsungAccessorySDK.csproj
@@ -14,7 +14,7 @@
     <AssemblyName>SamsungAccessorySDKNet</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <AndroidClassParser>class-parse</AndroidClassParser>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>


### PR DESCRIPTION
This change lowers the target framework of the package to Android Marshmallow. So that apps targeting lower versions can also use this binding.